### PR TITLE
Fix: approve and transfer

### DIFF
--- a/contracts/auction/LANDAuction.sol
+++ b/contracts/auction/LANDAuction.sol
@@ -284,7 +284,7 @@ contract LANDAuction is Ownable, LANDAuctionStorage {
         }
 
         // Remove approval of _fromToken owned by contract to be used by dex contract
-        require(_fromToken.clearApprove(address(dex)), "Error remove approval");
+        require(_fromToken.clearApprove(address(dex)), "Error clear approval");
 
         emit BidConversion(
             _bidId,

--- a/contracts/dex/KyberConverter.sol
+++ b/contracts/dex/KyberConverter.sol
@@ -66,10 +66,13 @@ contract KyberConverter is ITokenConverter {
 
         // Return the change of src token
         uint256 change = _srcToken.balanceOf(address(this)).sub(prevSrcBalance);
-        require(
-            _srcToken.safeTransfer(msg.sender, change),
-            "Could not transfer change to sender"
-        );
+
+        if (change > 0) {
+            require(
+                _srcToken.safeTransfer(msg.sender, change),
+                "Could not transfer change to sender"
+            );
+        }
 
 
         // Transfer amount of _destTokens to msg.sender

--- a/contracts/dex/KyberConverter.sol
+++ b/contracts/dex/KyberConverter.sol
@@ -58,7 +58,7 @@ contract KyberConverter is ITokenConverter {
         // Clean kyber to use _srcTokens on belhalf of this contract
         require(
             _srcToken.clearApprove(kyber),
-            "Could not clean approval of kyber to use _srcToken on behalf of this contract"
+            "Could not clear approval of kyber to use _srcToken on behalf of this contract"
         );
 
         // Check if the amount traded is equal to the expected one

--- a/contracts/libs/SafeERC20.sol
+++ b/contracts/libs/SafeERC20.sol
@@ -23,7 +23,13 @@ library SafeERC20 {
 
         require(prevBalance >= _value, "Insufficient funds");
 
-        _token.transfer(_to, _value);
+        bool success = address(_token).call(
+            abi.encodeWithSignature("transfer(address,uint256)", _to, _value)
+        );
+
+        if (!success) {
+            return false;
+        }
 
         require(prevBalance - _value == _token.balanceOf(address(this)), "Transfer failed");
 
@@ -49,7 +55,13 @@ library SafeERC20 {
         require(prevBalance >= _value, "Insufficient funds");
         require(_token.allowance(_from, address(this)) >= _value, "Insufficient allowance");
 
-        _token.transferFrom(_from, _to, _value);
+        bool success = address(_token).call(
+            abi.encodeWithSignature("transferFrom(address,address,uint256)", _from, _to, _value)
+        );
+
+        if (!success) {
+            return false;
+        }
 
         require(prevBalance - _value == _token.balanceOf(_from), "Transfer failed");
 
@@ -69,11 +81,9 @@ library SafeERC20 {
    * @param _value The amount of tokens to be spent.
    */
     function safeApprove(IERC20 _token, address _spender, uint256 _value) internal returns (bool) {
-        bool success = address(_token).call(abi.encodeWithSelector(
-            _token.approve.selector,
-            _spender,
-            _value
-        )); 
+        bool success = address(_token).call(
+            abi.encodeWithSignature("approve(address,uint256)",_spender, _value)
+        ); 
 
         if (!success) {
             return false;

--- a/full/KyberConverter.sol
+++ b/full/KyberConverter.sol
@@ -307,7 +307,7 @@ contract KyberConverter is ITokenConverter {
         // Clean kyber to use _srcTokens on belhalf of this contract
         require(
             _srcToken.clearApprove(kyber),
-            "Could not clean approval of kyber to use _srcToken on behalf of this contract"
+            "Could not clear approval of kyber to use _srcToken on behalf of this contract"
         );
 
         // Check if the amount traded is equal to the expected one

--- a/full/KyberConverter.sol
+++ b/full/KyberConverter.sol
@@ -174,7 +174,13 @@ library SafeERC20 {
 
         require(prevBalance >= _value, "Insufficient funds");
 
-        _token.transfer(_to, _value);
+        bool success = address(_token).call(
+            abi.encodeWithSignature("transfer(address,uint256)", _to, _value)
+        );
+
+        if (!success) {
+            return false;
+        }
 
         require(prevBalance - _value == _token.balanceOf(address(this)), "Transfer failed");
 
@@ -315,10 +321,13 @@ contract KyberConverter is ITokenConverter {
 
         // Return the change of src token
         uint256 change = _srcToken.balanceOf(address(this)).sub(prevSrcBalance);
-        require(
-            _srcToken.safeTransfer(msg.sender, change),
-            "Could not transfer change to sender"
-        );
+
+        if (change > 0) {
+            require(
+                _srcToken.safeTransfer(msg.sender, change),
+                "Could not transfer change to sender"
+            );
+        }
 
 
         // Transfer amount of _destTokens to msg.sender

--- a/full/KyberConverter.sol
+++ b/full/KyberConverter.sol
@@ -206,7 +206,13 @@ library SafeERC20 {
         require(prevBalance >= _value, "Insufficient funds");
         require(_token.allowance(_from, address(this)) >= _value, "Insufficient allowance");
 
-        _token.transferFrom(_from, _to, _value);
+        bool success = address(_token).call(
+            abi.encodeWithSignature("transferFrom(address,address,uint256)", _from, _to, _value)
+        );
+
+        if (!success) {
+            return false;
+        }
 
         require(prevBalance - _value == _token.balanceOf(_from), "Transfer failed");
 
@@ -226,11 +232,9 @@ library SafeERC20 {
    * @param _value The amount of tokens to be spent.
    */
     function safeApprove(IERC20 _token, address _spender, uint256 _value) internal returns (bool) {
-        bool success = address(_token).call(abi.encodeWithSelector(
-            _token.approve.selector,
-            _spender,
-            _value
-        )); 
+        bool success = address(_token).call(
+            abi.encodeWithSignature("approve(address,uint256)",_spender, _value)
+        ); 
 
         if (!success) {
             return false;

--- a/full/LANDAuction.sol
+++ b/full/LANDAuction.sol
@@ -320,7 +320,13 @@ library SafeERC20 {
         require(prevBalance >= _value, "Insufficient funds");
         require(_token.allowance(_from, address(this)) >= _value, "Insufficient allowance");
 
-        _token.transferFrom(_from, _to, _value);
+        bool success = address(_token).call(
+            abi.encodeWithSignature("transferFrom(address,address,uint256)", _from, _to, _value)
+        );
+
+        if (!success) {
+            return false;
+        }
 
         require(prevBalance - _value == _token.balanceOf(_from), "Transfer failed");
 
@@ -340,11 +346,9 @@ library SafeERC20 {
    * @param _value The amount of tokens to be spent.
    */
     function safeApprove(IERC20 _token, address _spender, uint256 _value) internal returns (bool) {
-        bool success = address(_token).call(abi.encodeWithSelector(
-            _token.approve.selector,
-            _spender,
-            _value
-        )); 
+        bool success = address(_token).call(
+            abi.encodeWithSignature("approve(address,uint256)",_spender, _value)
+        ); 
 
         if (!success) {
             return false;

--- a/full/LANDAuction.sol
+++ b/full/LANDAuction.sol
@@ -819,7 +819,7 @@ contract LANDAuction is Ownable, LANDAuctionStorage {
         }
 
         // Remove approval of _fromToken owned by contract to be used by dex contract
-        require(_fromToken.clearApprove(address(dex)), "Error remove approval");
+        require(_fromToken.clearApprove(address(dex)), "Error clear approval");
 
         emit BidConversion(
             _bidId,

--- a/full/LANDAuction.sol
+++ b/full/LANDAuction.sol
@@ -288,7 +288,13 @@ library SafeERC20 {
 
         require(prevBalance >= _value, "Insufficient funds");
 
-        _token.transfer(_to, _value);
+        bool success = address(_token).call(
+            abi.encodeWithSignature("transfer(address,uint256)", _to, _value)
+        );
+
+        if (!success) {
+            return false;
+        }
 
         require(prevBalance - _value == _token.balanceOf(address(this)), "Transfer failed");
 


### PR DESCRIPTION
Use `encodeWithSignature` instead of function selectors in order to avoid contract methods clashes